### PR TITLE
Apply execute perms to Entrypoint via Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,6 @@ RUN pip install -r requirements.txt
 
 EXPOSE 5000
 
+RUN chmod +x ./boot.sh
+
 ENTRYPOINT ["./boot.sh"]


### PR DESCRIPTION
Update Dockerfile to apply execute perms using chmod.
Uses RUN instead of just editing perms of boot.sh for
idempotence.

- Add line to Dockerfile which runs 'chmod +x' on the Entrypoint.

Resolves:
'docker: Error response from daemon: OCI runtime create failed:
container_linux.go:348: starting container process caused "exec:
"./boot.sh": permission denied": unknown.'