### PR TITLE
added optional environment variables  for logging for gunicorn and enms

### DIFF
--- a/config.py
+++ b/config.py
@@ -49,6 +49,10 @@ class Config(object):
     MAIL_USERNAME = environ.get('MAIL_USERNAME')
     MAIL_PASSWORD = environ.get('MAIL_PASSWORD')
 
+    # Logging
+    ENMS_LOG_LEVEL = environ.get('ENMS_LOG_LEVEL', 'DEBUG').upper()
+
+
     # Cluster
     # In production, for scalability and high-availability purposes, it is
     # recommended to deploy not one, but multiple instances of eNMS.

--- a/eNMS/__init__.py
+++ b/eNMS/__init__.py
@@ -99,7 +99,7 @@ def configure_errors(app):
 
 def configure_logs(app):
     basicConfig(
-        level=getattr(import_module('logging'),app.config['ENMS_LOG_LEVEL']),
+        level=getattr(import_module('logging'), app.config['ENMS_LOG_LEVEL']),
         format='%(asctime)s %(levelname)-8s %(message)s',
         datefmt='%m-%d-%Y %H:%M:%S',
         handlers=[

--- a/eNMS/__init__.py
+++ b/eNMS/__init__.py
@@ -1,6 +1,6 @@
 from flask import Flask, render_template
 from importlib import import_module
-from logging import basicConfig, DEBUG, info, StreamHandler
+from logging import basicConfig, info, StreamHandler
 from logging.handlers import RotatingFileHandler
 
 from eNMS.main import (
@@ -99,7 +99,7 @@ def configure_errors(app):
 
 def configure_logs(app):
     basicConfig(
-        level=DEBUG,
+        level=getattr(import_module('logging'),app.config['ENMS_LOG_LEVEL']),
         format='%(asctime)s %(levelname)-8s %(message)s',
         datefmt='%m-%d-%Y %H:%M:%S',
         handlers=[

--- a/gunicorn.py
+++ b/gunicorn.py
@@ -1,7 +1,8 @@
+from os import environ
 bind = '0.0.0.0:5000'
 workers = 5
-accesslog = '-'
-loglevel = 'debug'
+accesslog = environ.get('GUNICORN_ACCESS_LOG', '-')
+loglevel = environ.get('GUNICORN_LOG_LEVEL', 'debug').lower()
 capture_output = True
 enable_stdio_inheritance = True
 timeout = 1000


### PR DESCRIPTION
Added optional environment variables  to eNMS and Gunicorn per issue  #117 

Tested with the following commands on linux.

```bash
export ENMS_LOG_LEVEL='CRITICAL'
export GUNICORN_LOG_LEVEL='critical'
export GUNICORN_ACCESS_LOG='None'

./boot.sh 
```