### PR TITLE
[BUG] crash when user not found in base

### DIFF
--- a/eNMS/admin/routes.py
+++ b/eNMS/admin/routes.py
@@ -85,7 +85,7 @@ def login():
         name, password = request.form['name'], request.form['password']
         if request.form['authentication_method'] == 'Database':
             user = fetch('User', name=name)
-            if password == user.password:
+            if user and password == user.password:
                 login_user(user)
                 return redirect(url_for('base_blueprint.dashboard'))
             else:


### PR DESCRIPTION
eNMS does not support when the user is not found in database. No verification is done when object "user" is "None".