### PR TITLE
Allow netmiko user to specify config mode entry command

### DIFF
--- a/docs/automation/default_services.rst
+++ b/docs/automation/default_services.rst
@@ -166,6 +166,9 @@ Also included in Netmiko Advanced Parameters:
 .. note:: ``Expect String`` and ``Auto Find Prompt`` are mutually exclusive; both cannot be enabled at the same time.
    If the user does not expect Netmiko to find the prompt automatically, the user should provide the expected prompt instead.
 
+- ``Command to Enter Config Mode`` The default command used to enter config mode is determined by the Netmiko driver.
+  An alternate configuration mode entry command can be specified here to overrride the default.  Examples are the Juniper
+  ``config private`` and ``config exclusive`` commands that isolate configuration changes from other users.
 - ``Strip command`` Remove the echo of the command from the output (default: True).
 - ``Strip prompt`` Remove the trailing router prompt from the output (default: True).
 - ``Use Genie`` Use Cisco's Genie implementation to create structured data from cli commands. (Currently does not work

--- a/eNMS/forms.py
+++ b/eNMS/forms.py
@@ -947,7 +947,10 @@ class NetmikoForm(ConnectionForm):
     enable_mode = BooleanField(
         "Enable mode (run in enable mode or as root)", default=True
     )
-    config_mode = BooleanField("Config mode", default=False)
+    config_mode = BooleanField(
+        "Config mode (See Advanced Parameters to override the config mode command)",
+        default=False,
+    )
     fast_cli = BooleanField()
     timeout = FloatField(default=10.0)
     delay_factor = FloatField(

--- a/eNMS/runner.py
+++ b/eNMS/runner.py
@@ -888,7 +888,11 @@ class Runner:
             if mode and not self.config_mode:
                 connection.exit_config_mode()
             elif self.config_mode and not mode:
-                connection.config_mode()
+                connection.config_mode(
+                    config_command=self.config_mode_command
+                    if self.config_mode_command
+                    else None
+                )
         except Exception as exc:
             self.log("error", f"Failed to honor the config mode {exc}")
         return connection
@@ -920,7 +924,11 @@ class Runner:
         if self.enable_mode:
             netmiko_connection.enable()
         if self.config_mode:
-            netmiko_connection.config_mode()
+            netmiko_connection.config_mode(
+                config_command=self.config_mode_command
+                if self.config_mode_command
+                else None
+            )
         vs.connections_cache["netmiko"][self.parent_runtime][
             device.name
         ] = netmiko_connection

--- a/eNMS/services/data_validation/netmiko_validation.py
+++ b/eNMS/services/data_validation/netmiko_validation.py
@@ -23,6 +23,7 @@ class NetmikoValidationService(ConnectionService):
     delay_factor = db.Column(Float, default=1.0)
     global_delay_factor = db.Column(Float, default=1.0)
     expect_string = db.Column(db.SmallString)
+    config_mode_command = db.Column(db.SmallString)
     auto_find_prompt = db.Column(Boolean, default=True)
     strip_prompt = db.Column(Boolean, default=True)
     strip_command = db.Column(Boolean, default=True)
@@ -73,6 +74,9 @@ class NetmikoValidationForm(NetmikoForm):
     form_type = HiddenField(default="netmiko_validation_service")
     command = StringField(substitution=True)
     expect_string = StringField(substitution=True, help="netmiko/expect_string")
+    config_mode_command = StringField(
+        "Command to Enter Config Mode", default="", help="netmiko/config_mode_command"
+    )
     auto_find_prompt = BooleanField(default=True, help="netmiko/auto_find_prompt")
     strip_prompt = BooleanField(default=True, help="netmiko/strip_prompt")
     strip_command = BooleanField(default=True, help="netmiko/strip_command")
@@ -82,6 +86,7 @@ class NetmikoValidationForm(NetmikoForm):
         "Advanced Netmiko Parameters": {
             "commands": [
                 "expect_string",
+                "config_mode_command",
                 "auto_find_prompt",
                 "strip_prompt",
                 "strip_command",

--- a/eNMS/templates/help/netmiko/config_mode_command.html
+++ b/eNMS/templates/help/netmiko/config_mode_command.html
@@ -1,0 +1,30 @@
+<div class="modal-body">
+  <div>
+    <h2>Command to Enter Config Mode</h2>
+    <p>
+      Advanced users might want to specify options on the command for entering config mode.
+      This is useful on some devices to ensure that no other users are making concurrent configuration
+      changes or to isolate their changes from other users.
+    </p>
+    <p>
+      When no command is specified, the default command from the Netmiko driver is used.
+    </p>
+  </div>
+  <div>
+    <h2>Example 1</h2>
+    <h2>Juniper and Arista</h2>
+    <div>
+      <p>
+        Juniper and Arista both support <code class="help-snippet" style="…">config exclusive</code> to enter config mode only if
+        no other users are already in config, and to prevent other users from entering config mode until
+        the current configuration session completes.  They also support <code class="help-snippet" style="…">config private</code> to
+        ensure that changes committed in the current session include only commands entered in the session.
+      </p>
+      <p>
+        The default <code class="help-snippet" style="…">config</code> entry command, allows other concurrent changes and a
+        <code class="help-snippet" style="…">commit</code> in any session, commits config changes from all sessions.
+      </p>
+
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
This feature adds a new netmiko advanced section field that allows users to specify a command to be executed when enter config mode.  This will typically be used with values like "config private" or "config exclusive" that provide different ways to isolate changes from other sessions that might also be making configuration changes.  When not specified, the default behavior is unchanged.