### PR TITLE
fill entire width of select2's container

### DIFF
--- a/eNMS/static/js/base.js
+++ b/eNMS/static/js/base.js
@@ -509,6 +509,7 @@ function initSelect(el, model, parentId, single, constraints) {
     closeOnSelect: single ? true : false,
     dropdownParent: parentId ? $(`#${parentId}`) : $(document.body),
     tags: !single,
+    width: "100%",
     tokenSeparators: [","],
     ajax: {
       url: `/multiselect_filtering/${model}`,


### PR DESCRIPTION
Allow for select2 elements to fill the width of their parent element. Currently these elements don't change size when the page/modal is resized.

<img width="1085" alt="Screen Shot 2022-06-14 at 10 42 16 AM" src="https://user-images.githubusercontent.com/25757789/173619665-60dafca5-2d6f-4a10-bf8c-2fb50fbc625f.png">
